### PR TITLE
Fix NVFP4 FakeTensor compatibility with PyTorch 2.9.1

### DIFF
--- a/src/mmgp/offload.py
+++ b/src/mmgp/offload.py
@@ -3021,6 +3021,7 @@ class offload:
 
 
 
+    @torch.compiler.disable
     def _lora_linear_forward(self, model, submodule, loras_data, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         weight = submodule.weight
         bias = submodule.bias


### PR DESCRIPTION
Add @torch.compiler.disable decorator to _lora_linear_forward method to prevent torch.compile from tracing through NVFP4 quantized weight operations, avoiding FakeTensor mixing errors in PyTorch 2.9.1+.

This allows NVFP4 4-bit quantization to work correctly with RTX 50xx series GPUs and their optimized lightx2v kernels.