### PR TITLE
fix perc_reserved_mem_max env var

### DIFF
--- a/src/mmgp/offload.py
+++ b/src/mmgp/offload.py
@@ -217,7 +217,7 @@ def _compute_verbose_level(level):
 
 def _get_perc_reserved_mem_max(perc_reserved_mem_max = 0):
     if perc_reserved_mem_max <=0:
-        perc_reserved_mem_max = os.getenv("perc_reserved_mem_max", 0)
+        perc_reserved_mem_max = float(os.getenv("perc_reserved_mem_max", 0))
 
     if perc_reserved_mem_max <= 0:             
         perc_reserved_mem_max = 0.40 if os.name == 'nt' else 0.5        


### PR DESCRIPTION
```
    if perc_reserved_mem_max <= 0:
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'str' and 'int'```