### PR TITLE
A minor fix for memory budget calculation

### DIFF
--- a/src/mmgp/offload.py
+++ b/src/mmgp/offload.py
@@ -3623,9 +3623,8 @@ def all(pipe_or_dict_of_modules, pinnedMemory = False, pinnedPEFTLora = False, p
                 else:
                     print(f"Budget ({budget/ONE_MB:0.1f} MB) for Model '{model_id}' is too important so that this model can fit in the VRAM (max capacity is {self.device_mem_capacity/ONE_MB}) MB)")
                 print(f"Budget allocation for this model has been consequently reduced to the {coef * 100:.0f}% of max GPU Memory ({coef * self.device_mem_capacity/ONE_MB:0.1f} MB). This may not leave enough working VRAM and you will probably need to define manually a lower budget for this model.")
-                model_budget = coef * self.device_mem_capacity 
+            model_budget = coef * self.device_mem_capacity 
                 
-        
         model_budgets[model_id] = model_budget
 
 


### PR DESCRIPTION
I believe that there's a small indentation error when clamping the model memory budget; The actual issue will happen when setting the verbosity to less than 1; the model budget will not be clamped, and that causes the OOM at inference time;

old:
```
        if current_model_size > coef * self.device_mem_capacity and model_budget == 0 or model_budget > coef * self.device_mem_capacity:
            if verboseLevel >= 1:
                if model_budget == 0:
                    print(f"Model '{model_id}' is too large ({current_model_size/ONE_MB:0.1f} MB) to fit entirely in {coef * 100:.0f}% of the VRAM (max capacity is {coef * self.device_mem_capacity/ONE_MB:0.1f}) MB)")
                else:
                    print(f"Budget ({budget/ONE_MB:0.1f} MB) for Model '{model_id}' is too important so that this model can fit in the VRAM (max capacity is {self.device_mem_capacity/ONE_MB}) MB)")
                print(f"Budget allocation for this model has been consequently reduced to the {coef * 100:.0f}% of max GPU Memory ({coef * self.device_mem_capacity/ONE_MB:0.1f} MB). This may not leave enough working VRAM and you will probably need to define manually a lower budget for this model.")
                model_budget = coef * self.device_mem_capacity # <--- issue here
```

fix:
```
        if current_model_size > coef * self.device_mem_capacity and model_budget == 0 or model_budget > coef * self.device_mem_capacity:
            if verboseLevel >= 1:
                if model_budget == 0:
                    print(f"Model ...MB)")
                else:
                    print(f"Budget ... MB)")
                print(f"Budget ... for this model.")
            model_budget = coef * self.device_mem_capacity # <--- change the indentation level
```